### PR TITLE
Correção das ordens das mensagens e link para a sala

### DIFF
--- a/projeto/ntalk/sockets/chat.js
+++ b/projeto/ntalk/sockets/chat.js
@@ -23,23 +23,25 @@ module.exports = function(io) {
         ;
         sala = md5.update(timestamp).digest('hex');
       }
+      
       session.sala = sala;
       client.join(sala);
 
       var msg = "<b>"+usuario.nome+":</b> entrou.<br>";
-      redis.lpush(sala, msg, function(erro, res) {
-        redis.lrange(sala, 0, -1, function(erro, msgs) {
-          msgs.forEach(function(msg) {
-            sockets.in(sala).emit('send-client', msg);
-          });
+           
+      redis.lrange(sala, 0, -1, function(erro, msgs) {
+        msgs.forEach(function(msg) {
+        	client.emit('send-client', msg);
         });
+        redis.rpush(sala, msg);
+        sockets.in(sala).emit('send-client', msg);
       });
     });
 
     client.on('disconnect', function () {
       var sala = session.sala
         , msg = "<b>"+ usuario.nome +":</b> saiu.<br>";
-      redis.lpush(sala, msg);
+      redis.rpush(sala, msg);
       client.broadcast.emit('notify-offlines', usuario.email);
       sockets.in(sala).emit('send-client', msg);
       redis.srem('onlines', usuario.email);
@@ -50,7 +52,7 @@ module.exports = function(io) {
       var sala = session.sala
         , data = {email: usuario.email, sala: sala};
       msg = "<b>"+usuario.nome+":</b> "+msg+"<br>";
-      redis.lpush(sala, msg);
+      redis.rpush(sala, msg);
       client.broadcast.emit('new-message', data);
       sockets.in(sala).emit('send-client', msg);
     });

--- a/projeto/ntalk/views/chat/chat_script.ejs
+++ b/projeto/ntalk/views/chat/chat_script.ejs
@@ -1,6 +1,6 @@
 <script src="/socket.io/socket.io.js"></script>
 <script>
-  var socket = io.connect('http://localhost:3000');
+  var socket = io.connect('');
   
   socket.emit('join', '<%- sala %>');
   

--- a/projeto/ntalk/views/chat/chat_script.ejs
+++ b/projeto/ntalk/views/chat/chat_script.ejs
@@ -13,5 +13,6 @@
     var msg = document.getElementById('mensagem');
     socket.emit('send-server', msg.value);
     msg.value = '';
+    msg.focus();
   };
 </script>

--- a/projeto/ntalk/views/contatos/notify_script.ejs
+++ b/projeto/ntalk/views/contatos/notify_script.ejs
@@ -1,6 +1,6 @@
 <script src="/socket.io/socket.io.js"></script>
 <script>
-  var socket = io.connect('http://localhost:3000');
+  var socket = io.connect('');
   var notify = function(data) {
     var notify = document.getElementById(data.el);
     if (notify) {

--- a/projeto/ntalk/views/contatos/notify_script.ejs
+++ b/projeto/ntalk/views/contatos/notify_script.ejs
@@ -29,6 +29,6 @@
               , classes: 'label label-important'};
     notify(opts);
     var chat = document.getElementById('chat_' + data.email);
-    chat.href += '?sala=' + data.sala;
+    chat.href = '/chat?sala=' + data.sala;
   });
 </script>


### PR DESCRIPTION
Correção das ordens das mensagens que aparecem invertidas e link para a sala que está sendo concatenado a cada mensagem enviada.

Remoção do endereço do socket ao abrir conexão com o servidor Node para deixar o endereço mais dinâmico/flexível, talvez não seja a solução mais "didática" para o livro.

Melhoria de usabilidade retornando o foco para a caixa de mensagem.

